### PR TITLE
refactor: separa lógica de itens do pedido e corrige consistência de estoque

### DIFF
--- a/src/main/java/org/wita/erp/controllers/stock/StockController.java
+++ b/src/main/java/org/wita/erp/controllers/stock/StockController.java
@@ -11,6 +11,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.wita.erp.domain.entities.stock.StockMovement;
 import org.wita.erp.domain.entities.stock.dtos.CreateStockRequestDTO;
+import org.wita.erp.domain.entities.stock.dtos.StockMovementDTO;
 import org.wita.erp.domain.entities.stock.dtos.UpdateStockRequestDTO;
 import org.wita.erp.services.stock.StockService;
 
@@ -24,25 +25,25 @@ public class StockController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('STOCK_READ')")
-    public ResponseEntity<Page<StockMovement>> getAllStock(@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable, @RequestParam(required = false) String searchTerm) {
+    public ResponseEntity<Page<StockMovementDTO>> getAllStock(@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable, @RequestParam(required = false) String searchTerm) {
         return stockService.getAllStock(pageable, searchTerm);
     }
 
     @PostMapping("/create")
     @PreAuthorize("hasAuthority('STOCK_CREATE')")
-    public ResponseEntity<StockMovement> create(@Valid @RequestBody CreateStockRequestDTO data) {
+    public ResponseEntity<StockMovementDTO> create(@Valid @RequestBody CreateStockRequestDTO data) {
         return stockService.save(data);
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAuthority('STOCK_UPDATE')")
-    public ResponseEntity<StockMovement> update(@PathVariable UUID id, @RequestBody @Valid UpdateStockRequestDTO data) {
+    public ResponseEntity<StockMovementDTO> update(@PathVariable UUID id, @RequestBody @Valid UpdateStockRequestDTO data) {
         return stockService.update(id, data);
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('STOCK_DELETE')")
-    public ResponseEntity<StockMovement> delete(@PathVariable UUID id) {
+    public ResponseEntity<StockMovementDTO> delete(@PathVariable UUID id) {
         return stockService.delete(id);
     }
 }

--- a/src/main/java/org/wita/erp/controllers/transaction/order/OrderController.java
+++ b/src/main/java/org/wita/erp/controllers/transaction/order/OrderController.java
@@ -8,10 +8,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-import org.wita.erp.domain.entities.transaction.order.dtos.CreateOrderRequestDTO;
-import org.wita.erp.domain.entities.transaction.order.dtos.OrderDTO;
-import org.wita.erp.domain.entities.transaction.order.dtos.ProductOrderRequestDTO;
-import org.wita.erp.domain.entities.transaction.order.dtos.UpdateOrderRequestDTO;
+import org.wita.erp.domain.entities.transaction.order.dtos.*;
 import org.wita.erp.services.transaction.order.OrderService;
 
 import java.util.UUID;
@@ -34,11 +31,17 @@ public class OrderController {
         return orderService.save(data);
     }
 
-    /*@PostMapping("/add-item/{orderId}")
+    @PostMapping("/add-item/{orderId}")
     @PreAuthorize("hasAuthority('ORDER_UPDATE')")
-    public ResponseEntity<OrderDTO> addProductInOrder(@PathVariable UUID orderId, @RequestBody @Valid ProductOrderRequestDTO data) {
+    public ResponseEntity<OrderDTO> addProductInOrder(@PathVariable UUID orderId, @RequestBody @Valid ProductInOrderDTO data) {
         return orderService.addProductInOrder(orderId, data);
-    }*/
+    }
+
+    @PostMapping("/remove-item/{orderId}")
+    @PreAuthorize("hasAuthority('ORDER_UPDATE')")
+    public ResponseEntity<OrderDTO> removeProductInOrder(@PathVariable UUID orderId, @RequestBody @Valid ProductInOrderDTO data) {
+        return orderService.removeProductInOrder(orderId, data);
+    }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAuthority('ORDER_UPDATE')")

--- a/src/main/java/org/wita/erp/domain/entities/stock/dtos/CreateStockRequestDTO.java
+++ b/src/main/java/org/wita/erp/domain/entities/stock/dtos/CreateStockRequestDTO.java
@@ -9,5 +9,6 @@ public record CreateStockRequestDTO(@NotNull UUID product,
                                     @NotNull Integer quantity,
                                     @NotNull UUID movementReason,
                                     @NotNull UUID transaction,
-                                    @NotNull UUID user) {
+                                    @NotNull UUID user,
+                                    @NotNull StockMovementType movementType) {
 }

--- a/src/main/java/org/wita/erp/domain/entities/stock/dtos/StockMovementDTO.java
+++ b/src/main/java/org/wita/erp/domain/entities/stock/dtos/StockMovementDTO.java
@@ -1,0 +1,13 @@
+package org.wita.erp.domain.entities.stock.dtos;
+
+import org.wita.erp.domain.entities.stock.StockMovementType;
+import org.wita.erp.domain.entities.user.User;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record StockMovementDTO(UUID id, Product product, User user, MovementInfo movementInfo, String transactionCode, LocalDateTime createdAt) {
+    public record Product(UUID id, String name, Integer quantity, Integer quantityInStock) {}
+    public record User(UUID id, String name){}
+    public record MovementInfo(StockMovementType movementType, String movementReason){}
+}

--- a/src/main/java/org/wita/erp/domain/entities/stock/mappers/StockMapper.java
+++ b/src/main/java/org/wita/erp/domain/entities/stock/mappers/StockMapper.java
@@ -2,6 +2,7 @@ package org.wita.erp.domain.entities.stock.mappers;
 
 import org.mapstruct.*;
 import org.wita.erp.domain.entities.stock.StockMovement;
+import org.wita.erp.domain.entities.stock.dtos.StockMovementDTO;
 import org.wita.erp.domain.entities.stock.dtos.UpdateStockRequestDTO;
 
 @Mapper(componentModel = "spring")
@@ -12,4 +13,25 @@ public interface StockMapper {
     @Mapping(target = "user", ignore = true)
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void updateStockFromDTO(UpdateStockRequestDTO dto, @MappingTarget StockMovement stock);
+
+    @Mapping(target = "product", source = ".")
+    @Mapping(target = "user", source = "user")
+    @Mapping(target = "movementInfo", source = ".")
+    @Mapping(target = "transactionCode", source = "transaction.transactionCode")
+    StockMovementDTO StockMovementToDTO(StockMovement entity);
+
+
+    @Mapping(target = "id", source = "product.id")
+    @Mapping(target = "name", source = "product.name")
+    @Mapping(target = "quantity", source = "quantity")
+    @Mapping(target = "quantityInStock", source = "product.quantityInStock")
+    StockMovementDTO.Product mapProduct(StockMovement entity);
+
+    @Mapping(target = "id", source = "user.id")
+    @Mapping(target = "name", source = "user.name")
+    StockMovementDTO.User mapUser(org.wita.erp.domain.entities.user.User user);
+
+    @Mapping(target = "movementType", source = "stockMovementType")
+    @Mapping(target = "movementReason", source = "movementReason.reason")
+    StockMovementDTO.MovementInfo mapMovementInfo(StockMovement entity);
 }

--- a/src/main/java/org/wita/erp/domain/entities/transaction/order/dtos/ProductInOrderDTO.java
+++ b/src/main/java/org/wita/erp/domain/entities/transaction/order/dtos/ProductInOrderDTO.java
@@ -4,8 +4,8 @@ import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 
-public record ProductOrderRequestDTO(
-        @NotNull UUID productId,
-        @NotNull Integer quantity
-        ) {
+public record ProductInOrderDTO(
+        @NotNull ProductOrderRequestDTO product,
+        @NotNull UUID movementReason
+) {
 }

--- a/src/main/java/org/wita/erp/domain/entities/transaction/order/dtos/UpdateOrderRequestDTO.java
+++ b/src/main/java/org/wita/erp/domain/entities/transaction/order/dtos/UpdateOrderRequestDTO.java
@@ -9,8 +9,6 @@ public record UpdateOrderRequestDTO(BigDecimal value,
                                     UUID seller,
                                     UUID customer,
                                     UUID paymentType,
-                                    UUID movementReason,
                                     String transactionCode,
-                                    String description,
-                                    Set<ProductOrderRequestDTO> products) {
+                                    String description) {
 }

--- a/src/main/java/org/wita/erp/services/product/ProductService.java
+++ b/src/main/java/org/wita/erp/services/product/ProductService.java
@@ -114,6 +114,9 @@ public class ProductService {
         }
 
         else if (event.stockMovementType() == StockMovementType.OUT) {
+            if(product.getQuantityInStock() < event.quantity()) {
+                throw new ProductException("Product quantity out of stock", HttpStatus.CONFLICT);
+            }
             product.setQuantityInStock(product.getQuantityInStock() - event.quantity());
             productRepository.save(product);
         }

--- a/src/main/java/org/wita/erp/services/transaction/order/observers/AddProductInOrderObserver.java
+++ b/src/main/java/org/wita/erp/services/transaction/order/observers/AddProductInOrderObserver.java
@@ -1,0 +1,8 @@
+package org.wita.erp.services.transaction.order.observers;
+
+import org.wita.erp.domain.entities.transaction.order.dtos.ProductOrderRequestDTO;
+
+import java.util.UUID;
+
+public record AddProductInOrderObserver(UUID order, UUID movementReason, ProductOrderRequestDTO stockDifference) {
+}

--- a/src/main/java/org/wita/erp/services/transaction/order/observers/RemoveProductInOrderObserver.java
+++ b/src/main/java/org/wita/erp/services/transaction/order/observers/RemoveProductInOrderObserver.java
@@ -1,0 +1,8 @@
+package org.wita.erp.services.transaction.order.observers;
+
+import org.wita.erp.domain.entities.transaction.order.dtos.ProductOrderRequestDTO;
+
+import java.util.UUID;
+
+public record RemoveProductInOrderObserver(UUID order, UUID movementReason, ProductOrderRequestDTO stockDifference) {
+}


### PR DESCRIPTION
Em vez do usuário atualizar os produtos do pedido na rota Update, destrinchei em duas rotas novas, uma para adicionar e outra para remover produtos. Assim, tem mais controle na hora de manipular o estoque criando uma **saída** de estoque quando adicionado algum item e uma **entrada** quando removido algum item do pedido.